### PR TITLE
Add testimonial submission section before testimonials

### DIFF
--- a/src/components/landing/TestimonialSubmission.tsx
+++ b/src/components/landing/TestimonialSubmission.tsx
@@ -25,14 +25,20 @@ const TestimonialSubmission = () => {
           {/* Main content */}
           <div className="space-y-6 mb-8">
             <p className="text-lg text-gray-700 leading-relaxed">
-              We love hearing from our customers! If you've used this product, please send your honest feedback to{" "}
-              <span className="font-medium text-brand-600">lincomarket@gmail.com</span> — or simply click the button below to share your testimonial.
+              We love hearing from our customers! If you've used this product,
+              please send your honest feedback to{" "}
+              <span className="font-medium text-brand-600">
+                lincomarket@gmail.com
+              </span>{" "}
+              — or simply click the button below to share your testimonial.
             </p>
 
             <div className="flex items-start justify-center space-x-3 text-left max-w-2xl mx-auto">
               <Shield className="w-5 h-5 text-green-600 mt-1 flex-shrink-0" />
               <p className="text-gray-600">
-                ✅ We rotate these testimonials often to keep things fresh and genuine. Want to stay anonymous? Just let us know, and we'll keep your name private.
+                ✅ We rotate these testimonials often to keep things fresh and
+                genuine. Want to stay anonymous? Just let us know, and we'll
+                keep your name private.
               </p>
             </div>
           </div>

--- a/src/components/landing/TestimonialSubmission.tsx
+++ b/src/components/landing/TestimonialSubmission.tsx
@@ -1,0 +1,60 @@
+import { Button } from "@/components/ui/button";
+import { Mail, MessageSquare, Shield } from "lucide-react";
+
+const TestimonialSubmission = () => {
+  const handleSendTestimonial = () => {
+    const subject = encodeURIComponent("Testimonial for Herb Cutter");
+    const mailtoLink = `mailto:lincomarket@gmail.com?subject=${subject}`;
+    window.open(mailtoLink, "_blank");
+  };
+
+  return (
+    <section className="py-16 bg-gray-50">
+      <div className="container mx-auto px-4">
+        <div className="max-w-3xl mx-auto text-center">
+          {/* Header with emoji */}
+          <div className="mb-6">
+            <div className="inline-flex items-center justify-center w-16 h-16 bg-brand-100 rounded-full mb-4">
+              <MessageSquare className="w-8 h-8 text-brand-600" />
+            </div>
+            <h2 className="text-2xl md:text-3xl font-bold text-gray-900 mb-4">
+              🔧 Got Your Own Experience to Share?
+            </h2>
+          </div>
+
+          {/* Main content */}
+          <div className="space-y-6 mb-8">
+            <p className="text-lg text-gray-700 leading-relaxed">
+              We love hearing from our customers! If you've used this product, please send your honest feedback to{" "}
+              <span className="font-medium text-brand-600">lincomarket@gmail.com</span> — or simply click the button below to share your testimonial.
+            </p>
+
+            <div className="flex items-start justify-center space-x-3 text-left max-w-2xl mx-auto">
+              <Shield className="w-5 h-5 text-green-600 mt-1 flex-shrink-0" />
+              <p className="text-gray-600">
+                ✅ We rotate these testimonials often to keep things fresh and genuine. Want to stay anonymous? Just let us know, and we'll keep your name private.
+              </p>
+            </div>
+          </div>
+
+          {/* CTA Button */}
+          <Button
+            onClick={handleSendTestimonial}
+            size="lg"
+            className="bg-green-600 hover:bg-green-700 text-white px-8 py-3 text-lg font-medium transition-all duration-200 shadow-lg hover:shadow-xl"
+          >
+            <Mail className="w-5 h-5 mr-2" />
+            🔘 Send Testimonial
+          </Button>
+
+          {/* Small disclaimer */}
+          <p className="text-sm text-gray-500 mt-4">
+            Your feedback helps other customers make informed decisions
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default TestimonialSubmission;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -10,6 +10,7 @@ const Index = () => {
       <Hero />
       <Features />
       <Testimonials />
+      <TestimonialSubmission />
       <OrderSection />
 
       {/* Footer */}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,6 +1,7 @@
 import Hero from "@/components/landing/Hero";
 import Features from "@/components/landing/Features";
 import Testimonials from "@/components/landing/Testimonials";
+import TestimonialSubmission from "@/components/landing/TestimonialSubmission";
 import OrderSection from "@/components/landing/OrderSection";
 
 const Index = () => {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -9,8 +9,8 @@ const Index = () => {
     <div className="min-h-screen">
       <Hero />
       <Features />
-      <Testimonials />
       <TestimonialSubmission />
+      <Testimonials />
       <OrderSection />
 
       {/* Footer */}


### PR DESCRIPTION
## Purpose

The user wanted to add a new testimonial submission section to the landing page to encourage customer feedback. They specifically requested this section be positioned before the existing testimonials block to maximize its effectiveness in capturing user engagement. The section includes a call-to-action for users to share their experiences via email, with options for anonymous feedback and a professional design that matches the site's branding.

## Code Changes

- **Created new component**: `TestimonialSubmission.tsx` with responsive design featuring:
  - Light gray background (#f9f9f9) with proper padding and rounded corners
  - Center-aligned content with emoji icons and clear hierarchy
  - Professional green CTA button that opens email client with pre-filled subject
  - Privacy assurance messaging and mobile-friendly layout
- **Updated landing page**: Added `TestimonialSubmission` component to `Index.tsx` positioned before the existing `Testimonials` component
- **Email integration**: Implemented mailto link with encoded subject "Testimonial for Herb Cutter" targeting lincomarket@gmail.com

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/6badcffc63d448ed8fdcf1c42e775c14/spark-sanctuary)

👀 [Preview Link](https://6badcffc63d448ed8fdcf1c42e775c14-spark-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>6badcffc63d448ed8fdcf1c42e775c14</projectId>-->
<!--<branchName>spark-sanctuary</branchName>-->