### PR TITLE
Fix WhatsApp button text truncation on order page

### DIFF
--- a/src/components/ui/whatsapp-button.tsx
+++ b/src/components/ui/whatsapp-button.tsx
@@ -30,13 +30,10 @@ const WhatsAppButton = ({
     >
       <div className="text-center">
         <div className="text-base font-semibold">
-          📲 Get Instant Confirmation on WhatsApp
+          📲 Confirm Order on WhatsApp
         </div>
         <div className="text-xs mt-1 leading-tight opacity-90">
-          Click to avoid waiting for our call — our team will confirm
-          <br className="hidden sm:block" />
-          <span className="sm:hidden"> </span>and start processing your order
-          immediately
+          Skip the waiting — get instant order confirmation
         </div>
       </div>
     </Button>


### PR DESCRIPTION
## Purpose
Fix the WhatsApp order confirmation button text that was not displaying fully on the order confirmation page. The user requested adjustments to ensure the text appears completely while maintaining a clean and professional appearance.

## Code changes
- Shortened the main button text from "📲 Get Instant Confirmation on WhatsApp" to "📲 Confirm Order on WhatsApp"
- Simplified the subtitle from a multi-line explanation to a concise "Skip the waiting — get instant order confirmation"
- Removed responsive line break logic that was causing display issues
- Maintained the same visual styling and professional tone while improving readability

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/f17a66fa7f914cd09ae381402d0791c8/zenith-field)

👀 [Preview Link](https://f17a66fa7f914cd09ae381402d0791c8-zenith-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f17a66fa7f914cd09ae381402d0791c8</projectId>-->
<!--<branchName>zenith-field</branchName>-->