### PR TITLE
feat: Update treatment packages and order form UI

### DIFF
--- a/src/components/landing/OrderForm.tsx
+++ b/src/components/landing/OrderForm.tsx
@@ -285,7 +285,8 @@ const OrderForm = ({ selectedPackage }: OrderFormProps) => {
               Select Package *
             </Label>
             <p className="text-xs text-gray-600 -mt-1">
-              Most customers choose Complete or Premium, but all options deliver results. Pick what fits your budget and goals.
+              Most customers choose Complete or Premium, but all options deliver
+              results. Pick what fits your budget and goals.
             </p>
             <Select
               value={formData.packageType}

--- a/src/components/landing/OrderForm.tsx
+++ b/src/components/landing/OrderForm.tsx
@@ -52,14 +52,14 @@ const OrderForm = ({ selectedPackage }: OrderFormProps) => {
   });
 
   const packages = [
-    { name: "Premium Package (6 bottles)", bottles: 6, price: "₦55,500" },
+    { name: "Premium Treatment (6 bottles)", bottles: 6, price: "₦55,500" },
     {
-      name: "Complete Package (4 bottles)",
+      name: "Complete Treatment (4 bottles)",
       bottles: 4,
       price: "₦37,000",
       recommended: true,
     },
-    { name: "Basic Package (2 bottles)", bottles: 2, price: "₦20,500" },
+    { name: "Basic Treatment (2 bottles)", bottles: 2, price: "₦20,500" },
   ];
 
   const paymentMethods = [

--- a/src/components/landing/OrderForm.tsx
+++ b/src/components/landing/OrderForm.tsx
@@ -293,11 +293,16 @@ const OrderForm = ({ selectedPackage }: OrderFormProps) => {
                 <SelectValue placeholder="Choose your package" />
               </SelectTrigger>
               <SelectContent>
-                {packages.map((pkg) => (
+                {packages.map((pkg: any) => (
                   <SelectItem key={pkg.name} value={pkg.name}>
                     <div className="flex items-center justify-between w-full">
                       <div className="flex items-center">
                         <span>{pkg.name}</span>
+                        {pkg.featured && (
+                          <span className="ml-2 bg-purple-100 text-purple-800 text-xs px-2 py-0.5 rounded-full font-bold">
+                            BEST VALUE
+                          </span>
+                        )}
                         {pkg.recommended && (
                           <span className="ml-2 bg-orange-100 text-orange-800 text-xs px-2 py-0.5 rounded-full font-bold">
                             RECOMMENDED

--- a/src/components/landing/OrderForm.tsx
+++ b/src/components/landing/OrderForm.tsx
@@ -52,6 +52,12 @@ const OrderForm = ({ selectedPackage }: OrderFormProps) => {
   });
 
   const packages = [
+    {
+      name: "Ultimate Treatment (8 bottles + 1 free)",
+      bottles: 9,
+      price: "₦75,000",
+      featured: true,
+    },
     { name: "Premium Treatment (6 bottles)", bottles: 6, price: "₦55,500" },
     {
       name: "Complete Treatment (4 bottles)",

--- a/src/components/landing/OrderForm.tsx
+++ b/src/components/landing/OrderForm.tsx
@@ -284,6 +284,9 @@ const OrderForm = ({ selectedPackage }: OrderFormProps) => {
             <Label htmlFor="packageType" className="text-sm font-medium">
               Select Package *
             </Label>
+            <p className="text-xs text-gray-600 -mt-1">
+              Most customers choose Complete or Premium, but all options deliver results. Pick what fits your budget and goals.
+            </p>
             <Select
               value={formData.packageType}
               onValueChange={(value) => handleInputChange("packageType", value)}


### PR DESCRIPTION
## Purpose

Based on the conversation, the user wanted to enhance the product package selection by:

- Renaming "package" to "treatment" for better clarity.
- Introducing a new top-tier "Ultimate Treatment" package.
- Refining the helper text for the package selection to be more encouraging and less aggressive.

## Code changes

- **`src/components/landing/OrderForm.tsx`**
    - Renamed all instances of "Package" to "Treatment" in the `packages` array (e.g., "Basic Package" is now "Basic Treatment").
    - Added a new "Ultimate Treatment" package for ₦75,000, which includes a `featured` flag.
    - Updated the helper text under the "Select Package" dropdown to be more concise and less pushy.
    - Implemented a "BEST VALUE" tag that appears next to the new "Ultimate Treatment" option in the dropdown.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

🔗 [Edit in Builder.io](https://builder.io/app/projects/476d9a9332a2425b8c1a96393ae37b84/orbit-oasis)

👀 [Preview Link](https://476d9a9332a2425b8c1a96393ae37b84-orbit-oasis.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>476d9a9332a2425b8c1a96393ae37b84</projectId>-->
<!--<branchName>orbit-oasis</branchName>-->