### PR TITLE
Update Facebook Pixel ID in tracking config

### DIFF
--- a/src/lib/tracking.ts
+++ b/src/lib/tracking.ts
@@ -17,7 +17,7 @@ export const TRACKING_CONFIG = {
 
   // Facebook Pixel
   facebookPixel: {
-    pixelId: "470683655547090", // Replace with your Facebook Pixel ID
+    pixelId: "1638935730456352", // Replace with your Facebook Pixel ID
     enabled: true, // Set to true when you add your pixel ID
   },
 };


### PR DESCRIPTION
### Summary
This PR updates the Facebook Pixel ID in the application's tracking configuration to the new provided ID.

### Problem
The previously configured Facebook Pixel ID needed to be updated to match the new ID provided by the user.

### Solution
Updated the `pixelId` value in the global tracking configuration object to use the new identifier.

### Key Changes
* Replaced the old Facebook Pixel ID with `1638935730456352` in the `TRACKING_CONFIG` object within `src/lib/tracking.ts`.

---

<a href="https://builder.io/app/projects/ca744c58593c465781c021f22fd7045d/curry-haven"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ca744c58593c465781c021f22fd7045d-curry-haven.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 10`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ca744c58593c465781c021f22fd7045d</projectId>-->
<!--<branchName>curry-haven</branchName>-->